### PR TITLE
CDPTKAN-1101 Use new Jira board

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -33,8 +33,8 @@ class Site < ApplicationRecord
   def jira
     return if branch.blank?
 
-    if branch.downcase.starts_with?("cdpt")
-      "CDPT-#{branch.match(/\d+/)}"
+    if branch.downcase.starts_with?("cdptkan")
+      "CDPTKAN-#{branch.match(/\d+/)}"
     end
   end
 


### PR DESCRIPTION
The link to the Jira tickets uses the old Jira board and naming convention. It needs to use CDPTKAN-XXX