### PR TITLE
CDPTKAN-1221 Switch on Content Security Policy

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,22 +4,20 @@
 # See the Securing Rails Applications Guide for more information:
 # https://guides.rubyonrails.org/security.html#content-security-policy-header
 
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
-#
-#   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src style-src)
-#
-#   # Report violations without enforcing the policy.
-#   # config.content_security_policy_report_only = true
-# end
+Rails.application.configure do
+  config.content_security_policy do |policy|
+    policy.default_src :self
+    policy.font_src    :self
+    policy.img_src     :self, :data
+    policy.object_src  :none
+    policy.script_src  :self
+    policy.style_src   :self
+    policy.connect_src :self
+    policy.form_action :self
+    policy.frame_ancestors :none
+  end
+
+  # Generate session nonces for permitted inline scripts and styles.
+  config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
+  config.content_security_policy_nonce_directives = %w[script-src style-src]
+end


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/CDPTKAN-1221 

Enables the Rails CSP initializer as an XSS defence-in-depth measure. The policy restricts all resource loading to the same origin and blocks potentially dangerous browser features: